### PR TITLE
Remove call to undefined inspect.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -28,7 +28,6 @@ var createStartFn = function(tc, env) {
         return s + args[index++];
       });
     }
-    else msg = inspect(msg);
 
     for (var i = index; i < args.length; i++) {
       msg += ' ' + inspect(args[i]);


### PR DESCRIPTION
Hello. 

First of all, thanks for making this.

I just encountered this bug when trying to log a more complex object. As one can read in the code, a lot of stuff is `lifted from zuul`, but in zuul the function `inspect` is defined, as opposed to in karma-tap.

So this fixes that. In browsers the window.console.log is plenty for this job anyway. In my opinion :)
#### Steps to reproduce:
- Create a test that uses karma-tap as framework
- Try to log an object (for example `console.log({test: true})`
#### Result:

```
...snip...
 Uncaught ReferenceError: inspect is not defined
  at xxx/karma-tap/src/adapter.js:31
...snip...
```
#### Expected result

```
...snip...
Chrome 39.0.2171 (Mac OS X 10.9.5) LOG: Object{test: true}
...snip...
```

Thanks again for making this available, and have a great day!
