### PR TITLE
Add some timing and test count to karma output.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,17 +1,23 @@
 var createStartFn = function(tc, env) {
   var numResults = 0;
+  var res = [];
+  var startTime = new Date().getTime();
   var parse_stream = tapParser(function(results) {
     tc.info({ total: numResults });
+    for (var i = 0, len = res.length; i < len; i++) {
+      tc.result(res[i]);
+    }
     tc.complete({
       coverage: window.__coverage__
     });
   }).on('assert', function(assertion) {
     numResults++;
-    tc.result({
+    res.push({
       description: assertion.name,
       success: assertion.ok,
       log: [],
-      suite: []
+      suite: [],
+      time: new Date().getTime() - startTime
     });
   });
 


### PR DESCRIPTION
This fixes #1, but only in such a way that the time a certain assert has taken will not be displayed. On the other hand, it will display the total number of tests, and the total time.

Or, to put it into examples:
#### Without this PR:

```
Chrome 39.0.2171 (Mac OS X 10.9.5): Executed 2 of 0 SUCCESS (0.069 secs / NaN secs)
```
#### With this PR:

```
Chrome 39.0.2171 (Mac OS X 10.9.5): Executed 2 of 2 SUCCESS (0.001 secs / 0.799 secs)
```

So, you can see that we can't see how long the last test took to execute (or individual tests when other reports are used. 0.001 secs is the time it took to actually add the result), but we see the total time. 

So, if that is interesting to have, here is the PR. If not, no biggie :)

Have a nice day!
