### PR TITLE
Support Karma v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepublish": "npm run build-npm"
   },
   "peerDependencies": {
-    "karma": "1.x.x"
+    "karma": "1.x.x || 2.x.x"
   },
   "devDependencies": {
     "eslint": "3.x.x",


### PR DESCRIPTION
I have successfully used karma-tap with karma v2.

The breaking change in v2 is dropped support for EOL versions of node (0.10 and 0.12) - https://github.com/karma-runner/karma/releases/tag/v2.0.0


- Karma peer dependency supports karma@2.x.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bysabi/karma-tap/26)
<!-- Reviewable:end -->
